### PR TITLE
change the node manager from yarn to npm in the frontend github action

### DIFF
--- a/.github/workflows/frontend-stage-deploy.yaml
+++ b/.github/workflows/frontend-stage-deploy.yaml
@@ -21,7 +21,7 @@ jobs:
           node-version: "14"
 
       - name: Build website
-        run: yarn install && yarn build
+        run: npm install && npm run build
 
       - name: Create archive
         run: |


### PR DESCRIPTION
WHAT??
This PR change the package manager in the github action from frontend stage deployement from **yarn** to **npm**

WHY??
Because building the frontend with yarn throw some unexpected errors