### PR TITLE
Update endoint's fields to match the all backend

### DIFF
--- a/fastapi/onacut/models.py
+++ b/fastapi/onacut/models.py
@@ -52,11 +52,7 @@ class Region(Base):
     )
 
     def to_dict(self) -> dict:
-        return {
-            "id": self.id,
-            "name": self.name,
-            "num_alerts": len(self.alerts)
-        }
+        return {"id": self.id, "name": self.name, "num_alerts": len(self.alerts)}
 
 
 class City(Base):
@@ -83,7 +79,7 @@ class City(Base):
             "longitude": self.longitude,
             "lattitude": self.lattitude,
             "region_id": self.region_id,
-            "num_alerts": len(self.alerts)
+            "num_alerts": len(self.alerts),
         }
 
 
@@ -106,9 +102,8 @@ class District(Base):
             "id": self.id,
             "name": self.name,
             "city_id": self.city_id,
-            "num_alerts": len(self.alerts)
+            "num_alerts": len(self.alerts),
         }
-
 
 
 class Alert(Base):

--- a/fastapi/onacut/models.py
+++ b/fastapi/onacut/models.py
@@ -51,6 +51,13 @@ class Region(Base):
         lazy="dynamic",
     )
 
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "num_alerts": len(self.alerts)
+        }
+
 
 class City(Base):
     __tablename__ = "city"
@@ -69,6 +76,16 @@ class City(Base):
         lazy="dynamic",
     )
 
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "longitude": self.longitude,
+            "lattitude": self.lattitude,
+            "region_id": self.region_id,
+            "num_alerts": len(self.alerts)
+        }
+
 
 class District(Base):
     __tablename__ = "district"
@@ -83,6 +100,15 @@ class District(Base):
         backref=backref("districts", lazy="dynamic"),
         lazy="dynamic",
     )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "city_id": self.city_id,
+            "num_alerts": len(self.alerts)
+        }
+
 
 
 class Alert(Base):

--- a/fastapi/onacut/routers/cities.py
+++ b/fastapi/onacut/routers/cities.py
@@ -23,8 +23,8 @@ router = APIRouter(
     responses={403: {"description": "Operation forbidden"}},
 )
 def read_cities(db: Session = Depends(get_db)):
-    datas = db.query(CityModel).all()
-    return datas
+    cities = db.query(CityModel)
+    return list(map(lambda city: city.to_dict(), cities.all()))
 
 
 @router.get(
@@ -33,8 +33,8 @@ def read_cities(db: Session = Depends(get_db)):
     responses={403: {"description": "Operation forbidden"}},
 )
 def get_city(city_id: int, db: Session = Depends(get_db)):
-    data = db.query(CityModel).filter_by(id=city_id).first()
-    return data
+    city = db.query(CityModel).filter_by(id=city_id).first()
+    return city.to_dict()
 
 
 @router.post(

--- a/fastapi/onacut/routers/districts.py
+++ b/fastapi/onacut/routers/districts.py
@@ -23,8 +23,8 @@ router = APIRouter(
     responses={403: {"description": "Operation forbidden"}},
 )
 def read_districts(db: Session = Depends(get_db)):
-    data = db.query(DistrictModel).all()
-    return data
+    districts = db.query(DistrictModel)
+    return list(map(lambda district: district.to_dict(), districts.all()))
 
 
 @router.get(
@@ -33,8 +33,8 @@ def read_districts(db: Session = Depends(get_db)):
     responses={403: {"description": "Operation forbidden"}},
 )
 def get_district(district_id: int, db: Session = Depends(get_db)):
-    data = db.query(DistrictModel).filter_by(id=district_id).first()
-    return data
+    district = db.query(DistrictModel).filter_by(id=district_id).first()
+    return district.to_dict()
 
 
 @router.post(

--- a/fastapi/onacut/routers/regions.py
+++ b/fastapi/onacut/routers/regions.py
@@ -22,8 +22,8 @@ router = APIRouter(
     responses={403: {"description": "Operation forbidden"}},
 )
 def read_regions(db: Session = Depends(get_db)):
-    data = db.query(RegionModel).all()
-    return data
+    regions = db.query(RegionModel)
+    return list(map(lambda region: region.to_dict(), regions.all()))
 
 
 @router.get(
@@ -32,8 +32,8 @@ def read_regions(db: Session = Depends(get_db)):
     responses={403: {"description": "Operation forbidden"}},
 )
 def get_region(region_id: int, db: Session = Depends(get_db)):
-    data = db.query(RegionModel).filter_by(id=region_id).first()
-    return data
+    region = db.query(RegionModel).filter_by(id=region_id).first()
+    return region.to_dict()
 
 
 @router.post(

--- a/fastapi/onacut/schemas/city.py
+++ b/fastapi/onacut/schemas/city.py
@@ -22,7 +22,7 @@ class CityUpdate(CityBase):
 
 class City(CityBase):
     id: int
-    total_alerts: Union[int, None] = None
+    num_alerts: Union[int, None] = None
 
     class Config:
         orm_mode = True

--- a/fastapi/onacut/schemas/districts.py
+++ b/fastapi/onacut/schemas/districts.py
@@ -17,7 +17,7 @@ class DistrictUpdate(DistrictBase):
 
 
 class District(DistrictUpdate, DistrictBase):
-    total_alerts: Union[int, None] = None
+    num_alerts: Union[int, None] = None
 
     class Config:
         orm_mode = True

--- a/fastapi/onacut/schemas/region.py
+++ b/fastapi/onacut/schemas/region.py
@@ -17,7 +17,7 @@ class RegionUpdate(RegionBase):
 
 class Region(RegionBase):
     id: int | None
-    total_alerts: Union[int, None] = None
+    num_alerts: Union[int, None] = None
 
     class Config:
         orm_mode = True

--- a/fastapi/onacut/tests/routers/test_cities.py
+++ b/fastapi/onacut/tests/routers/test_cities.py
@@ -24,7 +24,7 @@ def test_add_city(random_name: str, metadata: dict, region_id: int) -> None:
     assert response.status_code == 200
     item = response.json()
     item.pop("id", None)  # delete the id from the response
-    item.pop("total_alerts", None)  # delete the total_alerts from the response
+    item.pop("num_alerts", None)  # delete the total_alerts from the response
     assert item == city
 
 

--- a/fastapi/onacut/tests/routers/test_districts.py
+++ b/fastapi/onacut/tests/routers/test_districts.py
@@ -13,7 +13,7 @@ def test_add_district(random_name: str, city_id: int) -> None:
     assert response.status_code == 200
     item = response.json()
     item.pop("id", None)  # delete the id from the response
-    item.pop("total_alerts", None)  # delete the total_alerts from the response
+    item.pop("num_alerts", None)  # delete the total_alerts from the response
     assert item == district
 
 

--- a/fastapi/onacut/tests/routers/test_regions.py
+++ b/fastapi/onacut/tests/routers/test_regions.py
@@ -14,7 +14,7 @@ def test_add_region(random_name: str) -> None:
     assert response.status_code == 200
     item = response.json()
     item.pop("id", None)  # delete the id from the response
-    item.pop("total_alerts", None)  # delete the total_alerts from the response
+    item.pop("num_alerts", None)  # delete the total_alerts from the response
     assert item == region
 
 


### PR DESCRIPTION
WHAT?
This PR update GET /cities /regions /districts fields to exactly match the All backend.


WHY?
To avoid unexpected error on the frontend